### PR TITLE
Correctly handle prefixed value functions

### DIFF
--- a/src/consistent.js
+++ b/src/consistent.js
@@ -931,16 +931,18 @@
 			} else if (typeof snapshot[name] === "function") {
 				if (!valueFunctionPrefix || name.indexOf(valueFunctionPrefix) === 0) {
 					/* Evaluate value functions */
-					var propertyName;
+					var propertyName,
+						value = snapshot[name].call(scope);
 					if(valueFunctionPrefix){
 						propertyName = name.replace(
 							new RegExp("^" + valueFunctionPrefix + "([A-Z])"),
 						   	function(){return arguments[1].toLowerCase()}
 						);
+						delete snapshot[name];
 					}else{
 						propertyName = name
 					}
-					snapshot[propertyName] = snapshot[name].call(scope);
+					snapshot[propertyName] = value;
 				} else {
 					/* Delete other functions as they are presumed to be foreign and not intended to
 					 * be used in the scope.


### PR DESCRIPTION
This fixes an issue where the incorrect attribute name was being set in the snapshot array.

This is probably not the best solution.

Given a function `getValueAvatar`, it sets `snapshot['avatar']` by removing `getValue` and lowercasing the first letter that's left (if it's a capital).
