### PR TITLE
Fix bug where function result not applied to scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,12 +259,12 @@ scope.$handleClick = function(ev) {
 };
 ```
 
-The handler function is called with `this` as the element that received the event, as in jQuery. There is also a second argument to the function which is the scope, in case you need it.
+The handler function is called with `this` as the scope. There is also a second argument to the function which is the element that triggered the event, in case you need it.
 
 ```javascript
-scope.$handleClick = function(ev, scope) {
-	scope.clickCount++;
-	scope.$.apply();
+scope.$handleClick = function(ev, dom) {
+	this.clickCount++;
+	this.$.apply();
 };
 ```
 

--- a/src/consistent.js
+++ b/src/consistent.js
@@ -1165,6 +1165,10 @@
 					snapshot[name] = snapshot[name].call(scope);
 				} else if (name.indexOf(valueFunctionPrefix) === 0) {
 					propertyName = propertyNameFromPrefixed(name, valueFunctionPrefix);
+					
+					/* Delete the cached result in the scope */
+					delete scope[propertyName]
+					
 					snapshot[propertyName] = snapshot[name].call(scope);
 
 					/* Delete the original value function */

--- a/src/consistent.js
+++ b/src/consistent.js
@@ -2044,7 +2044,7 @@
 										 * but this is not an error.
 										 */
 										if (func) {
-											var result = func.call(dom, ev, self._scope);
+											var result = func.call(self._scope, ev, dom);
 											if (result === false)
 												break;
 										}


### PR DESCRIPTION
Given the following

``` javascript
// Simplified for brevity and non coffee-ness
template = $('<tr ct-repeat="subscriptions">
            <td><input type="checkbox" name="state" ct="active" ct-on="toggleState" ct-hide="toggling" /></td>
        </tr>')
scope = template.consistent({valueFunctionPrefix: "get"})
scope.getActive = function(){
  return this.state == 'active';
}
scope.$toggleState = function(ev, scope){
  if(scope.state == 'active'){
    scope.state = 'inactive';
  }else{
    scope.state = 'active';
  }
  scope.$.apply();
}
```

The toggle state would never change from its initial value. Adding `delete this.active` to the `getActive` method showed that this seemed to be an issue with the element being saved, then reference rather than reevaluated.

Tracking it down in the code, I fixed the issue with this patch. I'm not sure what the actual issue is here, perhaps it's to do with the nested scopes? Perhaps not? This might not be the best solution, but it solved a few hours of frustrations :)
